### PR TITLE
Add g:perforce_use_cygpath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Restrict Perforce automatic operations (save/change read-only files) to a limite
 ##### g:perforce\_use\_relative\_paths _(default: 0)_
 Send relative file paths to Perforce so it can automatically detect which root to use (useful when sharing a Perforce repository between Linux and Windows or when using Cygwin).
 
+##### g:perforce\_use\_cygpath _(default: 0)_
+Use the cygpath utility to translate paths from Cygwin to absolute Windows paths. May work in cases where g:perforce\_use\_relative\_paths does not.
+
 ##### g:perforce\_prompt\_on\_open _(default: 1)_
 Whether to prompt the user when a file is open for edit (either on change or on save).
 

--- a/plugin/perforce.vim
+++ b/plugin/perforce.vim
@@ -44,6 +44,11 @@ endif
 if !exists('g:perforce_use_relative_paths')
   let g:perforce_use_relative_paths = 0
 endif
+" g:perforce_use_cygpath (0|1, default: 0)
+" Use cygpath to translate paths from cygwin to absolute windows paths
+if !exists('g:perforce_use_cygpath')
+  let g:perforce_use_cygpath = 0
+endif
 " g:perforce_prompt_on_open
 " Prompt when a file is opened either on change or on save
 if !exists('g:perforce_prompt_on_open')
@@ -83,6 +88,9 @@ function! s:P4ShellCurrentBuffer(cmd, ...)
     let l:filename = expand('%')
   else
     let l:filename = expand('%:p')
+  endif
+  if g:perforce_use_cygpath
+	  let l:filename = system('cygpath -wa ' . shellescape(l:filename) . ' | tr -d \\n')
   endif
   return call('s:P4Shell', [a:cmd . ' ' . shellescape(l:filename)] + a:000)
 endfunction
@@ -179,6 +187,9 @@ function! perforce#P4CallEditWithPrompt()
     let l:path = expand('%:h')
   else
     let l:path = expand('%:p:h')
+  endif
+  if g:perforce_use_cygpath
+	  let l:path = system('cygpath -wa ' . shellescape(l:path) . ' | tr -d \\n')
   endif
   if ! s:IsPathInP4(l:path)
     return


### PR DESCRIPTION
This option will call out to cygpath to translate a cygwin path into an
absolute Windows path that p4 can find, and works in cases where
relative paths won't.